### PR TITLE
Add interactive living room overlay

### DIFF
--- a/art-gallery.html
+++ b/art-gallery.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Art Gallery</title>
+    <link rel="stylesheet" href="scene.css">
+    <script src="scene.js" defer></script>
     <style>
         body {
             margin: 0;

--- a/assets/lamp.svg
+++ b/assets/lamp.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 120' stroke='#000' fill='none' stroke-width='3'>
+  <polygon points='10,20 50,20 40,60 20,60'/>
+  <line x1='30' y1='60' x2='30' y2='110'/>
+  <circle cx='30' cy='110' r='10'/>
+</svg>

--- a/assets/room-bg.svg
+++ b/assets/room-bg.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+  <rect width='600' height='400' fill='#222'/>
+  <rect y='250' width='600' height='150' fill='#111'/>
+</svg>

--- a/assets/sofa.svg
+++ b/assets/sofa.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 100' stroke='#000' fill='none' stroke-width='4'>
+  <rect x='20' y='40' width='160' height='40' rx='10' ry='10'/>
+  <rect x='30' y='20' width='140' height='40' rx='10' ry='10'/>
+  <line x1='20' y1='80' x2='20' y2='90'/>
+  <line x1='180' y1='80' x2='180' y2='90'/>
+</svg>

--- a/assets/tv.svg
+++ b/assets/tv.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 90' stroke='#000' fill='none' stroke-width='3'>
+  <rect x='10' y='10' width='100' height='60' rx='5'/>
+  <rect x='35' y='70' width='50' height='10'/>
+  <line x1='60' y1='70' x2='60' y2='90'/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Shroom of Doom</title>
+  <link rel="stylesheet" href="scene.css">
+  <script src="scene.js" defer></script>
   <style>
     /* ========== GLOBAL RESET ========== */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/info.html
+++ b/info.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Info Centre</title>
+    <link rel="stylesheet" href="scene.css">
+    <script src="scene.js" defer></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 2rem;
+            background: #0a0a0f;
+            color: #e6e6e6;
+            font-family: 'Courier New', monospace;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <h1>Info Centre</h1>
+    <p>Placeholder information page.</p>
+    <p><a href="index.html" style="color:#ff2e63;">Return Home</a></p>
+</body>
+</html>

--- a/scene.css
+++ b/scene.css
@@ -1,0 +1,108 @@
+/* Living room scene styles */
+#living-room {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 600px;
+  height: 400px;
+  background: url('assets/room-bg.svg') center/cover no-repeat;
+  border: 4px solid #000;
+  overflow: hidden;
+  filter: brightness(0.3);
+  transition: filter 0.5s;
+  z-index: 1000;
+}
+
+#living-room.lights-on {
+  filter: brightness(1);
+}
+
+#living-room .interactive {
+  position: absolute;
+  cursor: pointer;
+  transition: transform 0.3s, filter 0.3s;
+}
+
+#living-room .interactive:hover {
+  transform: scale(1.05);
+  filter: brightness(1.2);
+}
+
+#sofa {
+  width: 300px;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+#tv {
+  width: 150px;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+#lamp {
+  width: 60px;
+  top: 40px;
+  right: 60px;
+}
+
+.mushroom {
+  position: absolute;
+  width: 40px;
+  bottom: 0;
+}
+#mushroom-left { left: 20px; }
+#mushroom-right { right: 20px; }
+
+/* Drippy navigation boxes */
+.nav-box {
+  position: absolute;
+  padding: 10px 20px;
+  color: #fff;
+  text-decoration: none;
+  font-family: 'Courier New', monospace;
+  background: rgba(0, 0, 0, 0.6);
+  border: 2px solid #6f6;
+  border-radius: 4px;
+  animation: float 4s ease-in-out infinite;
+  cursor: pointer;
+  transform: translateX(-50%);
+}
+
+.nav-box:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.nav-box::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -10px;
+  width: 12px;
+  height: 12px;
+  background: #6f6;
+  border-radius: 0 0 6px 6px;
+  transform: translateX(-50%);
+}
+
+.nav-box.ooze::after {
+  animation: drip 0.6s infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translate(-50%, 0); }
+  50% { transform: translate(-50%, 10px); }
+}
+
+@keyframes drip {
+  0%, 100% { height: 12px; }
+  50% { height: 24px; }
+}
+
+/* Nav box positions */
+#nav-art { top: 20px; left: 30%; }
+#nav-shop { top: 20px; left: 50%; }
+#nav-info { top: 20px; left: 70%; }

--- a/scene.js
+++ b/scene.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const room = document.createElement('div');
+  room.id = 'living-room';
+  room.innerHTML = `
+    <img src="assets/sofa.svg" id="sofa" class="interactive" alt="sofa">
+    <img src="assets/tv.svg" id="tv" class="interactive" data-link="art-gallery.html" alt="tv">
+    <img src="assets/lamp.svg" id="lamp" class="interactive" data-link="info.html" alt="lamp">
+    <img src="assets/mushroom2.png" id="mushroom-left" class="mushroom" alt="mushroom">
+    <img src="assets/mushroom3.png" id="mushroom-right" class="mushroom" alt="mushroom">
+    <a id="nav-art" class="nav-box" data-link="art-gallery.html">THE ART</a>
+    <a id="nav-shop" class="nav-box" data-link="shop.html">THE SHOP</a>
+    <a id="nav-info" class="nav-box" data-link="info.html">THE INFO CENTRE</a>
+  `;
+  document.body.appendChild(room);
+
+  const interactives = room.querySelectorAll('.interactive, .nav-box');
+
+  interactives.forEach(el => {
+    el.addEventListener('click', e => {
+      e.preventDefault();
+      room.classList.add('lights-on');
+      el.classList.add('ooze');
+      const link = el.getAttribute('data-link');
+      if (link) {
+        setTimeout(() => {
+          window.location.href = link;
+        }, 500);
+      }
+    });
+  });
+});

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shop</title>
+    <link rel="stylesheet" href="scene.css">
+    <script src="scene.js" defer></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 2rem;
+            background: #0a0a0f;
+            color: #e6e6e6;
+            font-family: 'Courier New', monospace;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <h1>Shop</h1>
+    <p>Placeholder shop page.</p>
+    <p><a href="index.html" style="color:#ff2e63;">Return Home</a></p>
+</body>
+</html>

--- a/strange-loops-art.html
+++ b/strange-loops-art.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artifacts of Our Slicing</title>
+    <link rel="stylesheet" href="scene.css">
+    <script src="scene.js" defer></script>
     <style>
         body {
             margin: 0;


### PR DESCRIPTION
## Summary
- Add reusable living room overlay with clickable sofa, TV, lamp, and drippy navigation boxes
- Generate sketch-style SVG placeholders for furniture and background
- Introduce placeholder Shop and Info Centre pages and apply overlay across site

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ed7dfc6348320bd419bdca5bc890c